### PR TITLE
Fix download links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 A file download tool for AnVIL/TDR data identified by DRS URIs
 
-
 - [Installation](#installation)
   - [Checksum Verification](#checksum-verification)
 - [Running the Executable](#running-the-executable)
@@ -23,18 +22,16 @@ A file download tool for AnVIL/TDR data identified by DRS URIs
 
 ## Installation
 
-| Operating System | DRS Downloader                        | Checksum                       |
-| ---------------- | ------------------------------------- | ------------------------------ |
-| MacOS            | [drs-downloader-macOS.zip][macos]     | [checksums.txt](checksums)     |
-| Linux            | [drs-downloader-Linux.zip](Linux)     | [checksums.txt](checksums.txt) |
-| Windows          | [drs-downloader-Windows.zip](Windows) | [checksums.txt](checksums.txt) |
+| Operating System | DRS Downloader                        | Checksum                   |
+| ---------------- | ------------------------------------- | -------------------------- |
+| MacOS            | [drs-downloader-macOS][macos]         | [checksums.txt][checksums] |
+| Linux            | [drs-downloader-Linux][linux]         | [checksums.txt][checksums] |
+| Windows          | [drs-downloader-Windows.exe][windows] | [checksums.txt][checksums] |
 
-[macos]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-macOS.zip
-[linux]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-Linux.zip
-[windows]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-Windows.zip
+[macos]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-macOS
+[linux]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-Linux
+[windows]: https://github.com/anvilproject/drs_downloader/releases/latest/download/drs-downloader-Windows.exe
 [checksums]: https://github.com/anvilproject/drs_downloader/releases/latest/download/checksums.txt
-
-Download the latest `drs_downloader` zip file for your operating system. Unzipping the downloaded file will provide a `drs_downloader` executable file that can be run directly.
 
 ### Checksum Verification
 
@@ -43,7 +40,7 @@ In order to verify that the downloaded file can be trusted checksums are provide
 <details>
 <summary>Successful Verification</summary>
 
-To verify the integrity of the binaries on macOS run the following in the same directory as the downloaded zip file:
+To verify the integrity of the binaries on macOS run the following command in the same directory as the downloaded file:
 
 ```sh
 $ shasum -c checksums.txt --ignore-missing
@@ -67,6 +64,7 @@ shasum: checksums.txt: no file was verified
 ```
 
 In such a case please reach out to the contributors for assistance.
+
 </details>
 
 ## Running the Executable
@@ -80,14 +78,12 @@ chmod +x [filename]
 For mac you will also have to navigate to:
 System Preferences -> Security & Privacy -> Click button allow Exe to run
 
-
-
 ### Requirements
 
 The downloader requires that a Google Cloud project be designated as the billing project. In order for the downloader to authenticate and set the desired billing project the gcloud CLI tool must first be installed:
 
-* [gcloud CLI](https://cloud.google.com/sdk/docs/install) — used to authenticate the downloader and set the billing project.
-* [Python](https://www.python.org/) — required for gcloud CLI functionality.
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) — used to authenticate the downloader and set the billing project.
+- [Python](https://www.python.org/) — required for gcloud CLI functionality.
 
 #### Authentication
 
@@ -123,31 +119,35 @@ $ drs_downloader terra -m <manifest file> -d <destination directory>
 #### Arguments
 
 `-s, --silent`
+
 > Disables all output to the terminal during and after downloading.
 
 `-d, --destination_dir TEXT`
+
 > The directory or folder to download the DRS Objects to. Defaults to `/tmp/testing` if no value is provided.
 
 `-m, --manifest_path TEXT`
+
 > The manifest file that contains the DRS Objects to be downloaded. Typically a TSV file with one row per DRS Object.
 
 `--drs_header TEXT`
+
 > The value of the column in the manifest file containing the DRS Object IDs. Defaults to `pfb:ga4gh_drs_uri` if no value is provided.
 
-`--duplicate` 
->  downloads files and saves them into the specified directory even if there is already files with the same name already in the directory. Numbered naming is used
->  to specify the order of duplicates downloaded to the directory. For example: 1st -> original_file 2nd -> original_file(1) 3rd-> original_file(2) ... 
+`--duplicate`
+
+> downloads files and saves them into the specified directory even if there is already files with the same name already in the directory. Numbered naming is used
+> to specify the order of duplicates downloaded to the directory. For example: 1st -> original_file 2nd -> original_file(1) 3rd-> original_file(2) ...
 
 ### Basic Example
 
 The below command is a basic example of how to structure a download command with all of the required arguments. It uses:
 
-* a **manifest file** called [`terra-data.tsv`][terra-data] with 10 DRS Objects
-* a **DRS header value** of `pfb:ga4gh_drs_uri` within the manifest file to reference the DRS Objects. It can be omitted since this is the default value used by the downloader.
-* a **download directory** called `DATA` as the destination
+- a **manifest file** called [`terra-data.tsv`][terra-data] with 10 DRS Objects
+- a **DRS header value** of `pfb:ga4gh_drs_uri` within the manifest file to reference the DRS Objects. It can be omitted since this is the default value used by the downloader.
+- a **download directory** called `DATA` as the destination
 
 [terra-data]: https://github.com/anvilproject/drs_downloader/blob/feature/download-recovery/tests/fixtures/manifests/terra-data.tsv
-
 
 ```sh
 $ drs_downloader terra -m tests/fixtures/manifest/terra-data.tsv -d DATA
@@ -179,7 +179,6 @@ NA18613.final.cram.crai NA20525.final.cram.crai
 
 ### Example with a Different Header Value
 
-
 Let's take a look at different manifest file called [`terra-different-header.tsv`][terra-different-header]. Namely the DRS header value is now `drs_uri` so we will need to tell the downloader which column to find the DRS URI's in the manifest with the `--drs_header` flag:
 
 ```sh
@@ -188,8 +187,7 @@ drs_downloader terra -m tests/fixtures/manifests/terra-different-header.tsv -d D
 
 This will download the DRS Objects specified in the `drs_uri` column into the `DATA` directory just as before.
 
-[terra-different-header]: https://github.com/anvilproject/drs_downloader/blob/feature/download-recovery/tests/fixtures/manifests/terra-different-header.tsv 
-
+[terra-different-header]: https://github.com/anvilproject/drs_downloader/blob/feature/download-recovery/tests/fixtures/manifests/terra-different-header.tsv
 
 ### Help/Additional Options
 


### PR DESCRIPTION
Previous links in README pointed to the outdated ZIP files. Updated links to reference latest binary releases and checksum files.