### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,10 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    target-branch: "develop"
+    groups:
+      dependabot:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
Updates Dependabot:
- Run daily instead of weekly
- Group all security updates into one PR (easier to merge, less conflicts) 

Discussion on Snyk vs Dependabot (or use both?)