### PR TITLE
feat: Add initial GitHub Action workflow for building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+# Build the MkDocs site and deploy it to GitHub Pages.
+# References:
+#   https://www.mkdocs.org/
+#   https://github.com/actions/deploy-pages
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Build site
+        run: mkdocs build --site-dir site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Overview

This PR adds a small GitHub Action workflow to build the site docs on every push to the `main` branch.

> [!IMPORTANT]
> 
> Pages source is currently set to `Deploy from a branch` in the [settings](https://github.com/anvilproject/drs_downloader/settings/pages)
>
> This PR requires that we update this `GitHub Actions` for this workflow to take effect.